### PR TITLE
Serve browser client from Socket.IO server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
-#　Stick Fighterの動かし方
-   `server` 側の人がcmdでnode サーバーを起動
-   `client` 側の人がcmdでviteを起動します
-## セットアップ手順
-　　`client/script.js`の19行目をサーバーを立てるPCのローカル(プライベート)IPに変更してください
+# Stick Fighterの動かし方
 
-   `server`側　cmd　
-    ```
-        npm run dev
-    ```
-   `client`側　cmd
-    ```
-    node server.js
-    ```
+サーバーを起動すると、同じポートでクライアント用のページも配信されます。プレイヤーはブラウザでサーバーのURLにアクセスするだけで参加できます。
 
-### ラグをいじる設定はscript.jsの109行目にあります
+## セットアップ
+1. 依存関係をインストールしてクライアントをビルドします。
+   ```bash
+   cd client
+   npm install
+   npm run build
+   cd ../server
+   npm install
+   ```
+
+## サーバーの起動
+1. `server` ディレクトリで Socket.IO サーバーを起動します。
+   ```bash
+   npm start
+   ```
+2. ブラウザで `http://<サーバーのホスト名またはIP>:3000` にアクセスするとゲームが開始できます。
+
+> **Note:** `client/script.js` を編集してIPアドレスを指定する必要はなくなりました。サーバーと同じホスト・ポートで自動的にSocket.IOへ接続します。

--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,8 @@
   "name": "kakuge-client",
   "version": "1.0.0",
   "scripts": {
-    "dev": "vite"
+    "dev": "vite",
+    "build": "vite build"
   },
   "dependencies": {
     "phaser": "^3.70.0",

--- a/client/script.js
+++ b/client/script.js
@@ -16,7 +16,7 @@ const resolveSocketUrl = () => {
   return `${protocol}//${hostname}${port ? `:${port}` : ''}`;
 };
 
-const socket = io("http://192.168.10.112:3000", );
+const socket = io(resolveSocketUrl());
 
 const COLORS = [
   { hex: '#000000', label: 'ブラック' },


### PR DESCRIPTION
## Summary
- connect the browser client to the active Socket.IO host instead of a fixed IP
- serve the built client bundle and SPA fallback from the Socket.IO server
- document the new workflow and add a production build script for the client

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68fed06a6c24832da434a886b5d67f95